### PR TITLE
Add MindMac to Apps section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@
 - [ChatGPT Desktop Application](https://github.com/lencx/ChatGPT) - Cross-platform web UI wrapper. (Electron)
 - [ChatGPT Android](https://github.com/skydoves/chatgpt-android) - Native Android app.
 - [ChatARKit](https://github.com/trzy/ChatARKit) - iOS app for creating AR experiences with natural language.
+- [MindMac](https://mindmac.app) - Intuitive native macOS app powered by ChatGPT API. (Freemium)
 
 ## Web apps
 


### PR DESCRIPTION
Add MindMac - Intuitive native macOS app powered by ChatGPT API to Apps section.

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-chatgpt/blob/main/contributing.md) twice and made sure my submission follows it.**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
