### PR TITLE
Add ChatGPT Widescreen to browser extensions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,6 +133,7 @@
 - [ChatGPT for Google Colab](https://github.com/ali-h-kudeir/ChatGPT-Google-Colab) - Embed ChatGPT inside Google Colab.
 - [codereview.gpt](https://github.com/sturdy-dev/codereview.gpt) - Reviews your pull requests.
 - [GPT2Markdown](https://github.com/0xreeko/gpt2markdown) - Export your ChatGPT conversations to Markdown.
+- [ChatGPT Widescreen Mode](https://github.com/adamlui/chatgpt-widescreen) - Adds widescreen and full-window mode to ChatGPT.
 
 **User scripts**
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-chatgpt/blob/main/contributing.md) twice and made sure my submission follows it.**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

This extension already exists in the userscripts section, but also happens to be a browser extension (for Chrome & Edge)