### PR TITLE
Add OpenClaw

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -236,7 +236,7 @@
 - [DuckDuckGPT](https://github.com/kudoai/duckduckgpt) - DuckDuckGo bot.
 - [BraveGPT](https://github.com/kudoai/bravegpt) - Brave Search bot.
 - [GoogleGPT](https://www.googlegpt.io) - Google Search bot.
-- [OpenClaw](https://github.com/openclaw/openclaw) - Self-hosted multi-channel bot bridging Claude to WhatsApp, Telegram, Discord, Slack, and more. ([Setup](https://clawdbot.blog/getting-started/installation/))
+- [OpenClaw](https://github.com/openclaw/openclaw) - Self-hosted multi-channel bot bridging Claude to WhatsApp, Telegram, Discord, Slack, and more.
 
 ## Integrations
 

--- a/readme.md
+++ b/readme.md
@@ -236,6 +236,7 @@
 - [DuckDuckGPT](https://github.com/kudoai/duckduckgpt) - DuckDuckGo bot.
 - [BraveGPT](https://github.com/kudoai/bravegpt) - Brave Search bot.
 - [GoogleGPT](https://www.googlegpt.io) - Google Search bot.
+- [OpenClaw](https://github.com/openclaw/openclaw) - Self-hosted multi-channel bot bridging Claude to WhatsApp, Telegram, Discord, Slack, and more. ([Setup](https://clawdbot.blog/getting-started/installation/))
 
 ## Integrations
 


### PR DESCRIPTION
Adding [OpenClaw](https://github.com/openclaw/openclaw) to the Bots section.

OpenClaw is a self-hosted, open-source multi-channel bot that connects Claude to WhatsApp, Telegram, Discord, Slack, iMessage, SMS, Email, and Signal from a single deployment.

- **GitHub**: https://github.com/openclaw/openclaw (190k+ stars, MIT)
- **Setup Guide**: https://clawdbot.blog/getting-started/installation/