### PR TITLE
Add Rival

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@
 - [Wielded](https://wielded.com) - Web UI that works for OpenAI, Azure, Anthropic, and AWS Bedrock. Free for individuals.
 - [Price Per Token](https://pricepertoken.com) - Compare LLM API pricing across providers. Includes token counter and cost calculator.
 - [Taskade](https://taskade.com) - AI-powered workspace with custom AI agents, multi-model support (GPT, Claude, Gemini), project management, and workflow automation for teams.
+- [Rival](https://rival.tips) - Compare AI model outputs side-by-side with blind preference voting and a multi-model Prompt Lab.
 
 ### Self-hosted
 


### PR DESCRIPTION
Add Rival to the Hosted web apps section.

Rival lets users compare AI model outputs (ChatGPT, Claude, Gemini, and 200+ others) side-by-side in blind A/B tests. Includes community-driven rankings and a Prompt Lab for running custom prompts across multiple models simultaneously.